### PR TITLE
Added secrets file to serve env var

### DIFF
--- a/kubectl_deploy/deployment.yaml
+++ b/kubectl_deploy/deployment.yaml
@@ -13,7 +13,7 @@ spec:
     metadata:
       labels:
         app: django-container
-   	spec:
+    spec:
       containers:
         - name: django
           image: 926803513772.dkr.ecr.eu-west-1.amazonaws.com/cloud-platform-demo-app:latest
@@ -24,3 +24,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: djangosecret
+                  key: secretKey

--- a/kubectl_deploy/secret.yaml
+++ b/kubectl_deploy/secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: djangosecret
+type: Opaque
+data:
+  secretKey: dGhpc2lzVGhlU2VjcmV0S2V5Tm90aGluZ1RvU2VlSGVyZS4=


### PR DESCRIPTION
**WHAT**
To write the Django secret key to an environment variable, a secret has been created and is called by the deployment.yaml. This secret is not encrypted as we've taken the decision to leave it for the quickstart.

**WHY**
The settings.py in the project config refers to an environment variable named SECRET_KEY which currently doesn't exist. This causes the app to fail. This PR addresses that issue. 