### PR TITLE
Fixup: Allowed Hosts and Django Secrets.

### DIFF
--- a/django-reference-app/django-ref-config/settings.py
+++ b/django-reference-app/django-ref-config/settings.py
@@ -27,7 +27,7 @@ DEBUG = True
 
 ALLOWED_HOSTS = [
   os.environ.get('SERVER_IP', '127.0.0.1'),
-  os.environ.get('SERVER_HOSTNAME', 'localhost'),
+  os.environ.get('DOMAIN_NAME', 'localhost'),
 ]
 
 # Application definition

--- a/kubectl_deploy/deployment.yaml
+++ b/kubectl_deploy/deployment.yaml
@@ -13,7 +13,7 @@ spec:
     metadata:
       labels:
         app: django-container
-   	spec:
+    spec:
       containers:
         - name: django
           image: 926803513772.dkr.ecr.eu-west-1.amazonaws.com/cloud-platform-demo-app:latest
@@ -24,3 +24,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: djangosecret
+                  key: secretKey

--- a/kubectl_deploy/deployment.yaml
+++ b/kubectl_deploy/deployment.yaml
@@ -29,3 +29,5 @@ spec:
                 secretKeyRef:
                   name: djangosecret
                   key: secretKey
+            - name: DOMAIN_NAME
+              value: .k8s.integration.dsd.io

--- a/kubectl_deploy/secret.yaml
+++ b/kubectl_deploy/secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: djangosecret
+type: Opaque
+data:
+  secretKey: dGhpc2lzVGhlU2VjcmV0S2V5Tm90aGluZ1RvU2VlSGVyZS4=


### PR DESCRIPTION
This PR comprises of two changes. The first is to fix an issue with the allowed hosts. The second is to write the Django secret to an env variable.  

**What**
1. A change to the deployment manifest, allowing the export the domain name in an environment variable. Also included, a change to the settings.py to allow my wildcarded domain name. 

2. To write the Django secret key to an environment variable, a secret has been created and is called by the deployment.yaml. This secret is not encrypted as we've taken the decision to leave it for the quickstart.

**Why**
1. The settings.py in the project config refers to an environment variable named SECRET_KEY which currently doesn't exist. This causes the app to fail. This PR addresses that issue.

2. This will fix the issue we're experiencing with allowed_hosts and also allow users to use multiple endpoints as outlined in: 
https://github.com/ministryofjustice/cloud-platform-reference-app/issues/7
