### PR TITLE
Added boto3 as requirement and changed DB entry

### DIFF
--- a/django_reference_app/django_ref_config/settings.py
+++ b/django_reference_app/django_ref_config/settings.py
@@ -80,11 +80,15 @@ WSGI_APPLICATION = 'django_ref_config.wsgi.application'
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
-    }
-}
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': 'kubernetes_django',
+        'USER': os.getenv('POSTGRES_USER'),
+        'PASSWORD': os.getenv('POSTGRES_PASSWORD'),
+        'HOST': os.getenv('POSTGRES_HOST'),
+        'PORT': os.getenv('POSTGRES_PORT', 5432)
 
+     }
+}
 
 # Password validation
 # https://docs.djangoproject.com/en/2.0/ref/settings/#auth-password-validators

--- a/django_reference_app/django_ref_config/settings.py
+++ b/django_reference_app/django_ref_config/settings.py
@@ -81,7 +81,7 @@ WSGI_APPLICATION = 'django_ref_config.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
-        'NAME': 'kubernetes_django',
+        'NAME': 'django_reference',
         'USER': os.getenv('POSTGRES_USER'),
         'PASSWORD': os.getenv('POSTGRES_PASSWORD'),
         'HOST': os.getenv('POSTGRES_HOST'),

--- a/kubectl_deploy/postgres/deployment.yaml
+++ b/kubectl_deploy/postgres/deployment.yaml
@@ -30,7 +30,7 @@ spec:
                   key: password
 
             - name: POSTGRES_DB
-              value: kubernetes_django
+              value: django_reference
 
           ports:
             - containerPort: 5432

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Django==2.0.5
 django-govuk-template==0.7
 django-govuk-forms==0.6
 psycopg2-binary==2.7.4
+boto3==1.7.10


### PR DESCRIPTION
**WHAT**
1. Amended the settings.py, allowing an on cluster postgres db to be used. 
2. Change in the requirements.txt to allow boto3 install.

**WHY**
1. This will allow us to hook up the on-cluster db. The env vars are passed to the pod via the deployment manifest file. 
2. This will enable the s3 secrets function.