### PR TITLE
Fix issues with Helm deployment manifest

### DIFF
--- a/django_reference_app/django_ref_config/settings.py
+++ b/django_reference_app/django_ref_config/settings.py
@@ -87,6 +87,7 @@ DATABASES = {
         'PASSWORD': os.getenv('POSTGRES_PASSWORD'),
         'HOST': os.getenv('POSTGRES_HOST'),
         'PORT': os.getenv('POSTGRES_PORT', 5432),
+# Added connect_timeout to ensure the app exits if the database connection times out
         'OPTIONS': {
             'connect_timeout': 5,
         }

--- a/django_reference_app/django_ref_config/settings.py
+++ b/django_reference_app/django_ref_config/settings.py
@@ -9,7 +9,6 @@ https://docs.djangoproject.com/en/2.0/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/2.0/ref/settings/
 """
-
 import os
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
@@ -26,7 +25,9 @@ SECRET_KEY = os.environ.get('SECRET_KEY', '')
 DEBUG = True
 
 ALLOWED_HOSTS = [
+  os.environ.get('SERVER_IP', '127.0.0.1'),
   os.environ.get('SERVER_NAME', 'localhost'),
+
 ]
 
 # Application definition
@@ -85,8 +86,10 @@ DATABASES = {
         'USER': os.getenv('POSTGRES_USER'),
         'PASSWORD': os.getenv('POSTGRES_PASSWORD'),
         'HOST': os.getenv('POSTGRES_HOST'),
-        'PORT': os.getenv('POSTGRES_PORT', 5432)
-
+        'PORT': os.getenv('POSTGRES_PORT', 5432),
+        'OPTIONS': {
+            'connect_timeout': 5,
+        }
      }
 }
 

--- a/helm_deploy/django-app/templates/deployment.yaml
+++ b/helm_deploy/django-app/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
                 name: {{ template "django-app.fullname" . }}
                 key: secretKey
           - name: SERVER_NAME
-            value: {{required "URL is required" .Values.deploy.host }}
+            value: {{required "URL is required" .Values.deploy.host | quote }}
           - name: POSTGRES_USER
             valueFrom:
               secretKeyRef:

--- a/helm_deploy/django-app/templates/deployment.yaml
+++ b/helm_deploy/django-app/templates/deployment.yaml
@@ -24,13 +24,17 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
+          - name: SERVER_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
           - name: SECRET_KEY
             valueFrom:
               secretKeyRef:
                 name: {{ template "django-app.fullname" . }}
                 key: secretKey
           - name: SERVER_NAME
-            value: {{ default "" .Values.ingress.hosts | quote }}
+            value: {{ default "" .Values.deploy.hosts | quote }}
           - name: POSTGRES_USER
             valueFrom:
               secretKeyRef:
@@ -47,4 +51,9 @@ spec:
             value: {{ .Values.postgresql.postgresDatabase }}
           ports:
             - containerPort: 8000
-      
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 5

--- a/helm_deploy/django-app/templates/deployment.yaml
+++ b/helm_deploy/django-app/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
                 name: {{ template "django-app.fullname" . }}
                 key: secretKey
           - name: SERVER_NAME
-            value: {{ default "" .Values.deploy.host | quote }}
+            value: {{required "URL is required" .Values.deploy.host }}
           - name: POSTGRES_USER
             valueFrom:
               secretKeyRef:

--- a/helm_deploy/django-app/templates/deployment.yaml
+++ b/helm_deploy/django-app/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
                 name: {{ template "django-app.fullname" . }}
                 key: secretKey
           - name: SERVER_NAME
-            value: {{ default "" .Values.deploy.hosts | quote }}
+            value: {{ default "" .Values.deploy.host | quote }}
           - name: POSTGRES_USER
             valueFrom:
               secretKeyRef:

--- a/helm_deploy/django-app/templates/ingress.yaml
+++ b/helm_deploy/django-app/templates/ingress.yaml
@@ -26,7 +26,7 @@ spec:
   {{- end }}
 {{- end }}
   rules:
-    - host: {{ .Values.deploy.hosts }}
+    - host: {{ .Values.deploy.host }}
       http:
         paths:
           - path: {{ $ingressPath }}

--- a/helm_deploy/django-app/templates/ingress.yaml
+++ b/helm_deploy/django-app/templates/ingress.yaml
@@ -26,13 +26,11 @@ spec:
   {{- end }}
 {{- end }}
   rules:
-  {{- range .Values.ingress.hosts }}
-    - host: {{ . }}
+    - host: {{ .Values.deploy.hosts }}
       http:
         paths:
           - path: {{ $ingressPath }}
             backend:
               serviceName: {{ $fullName }}
               servicePort: 8000
-  {{- end }}
 {{- end }}

--- a/helm_deploy/django-app/templates/job-migration.yaml
+++ b/helm_deploy/django-app/templates/job-migration.yaml
@@ -1,0 +1,36 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "django-app.fullname" . }}-db-migration
+spec:
+  template:
+    spec:
+      containers:
+        - name: {{ template "django-app.fullname" . }}-db-migration
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/bin/bash","-c","python3 django_reference_app/manage.py migrate"]
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "django-app.fullname" . }}
+                  key: postgresUser
+
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "django-app.fullname" . }}
+                  key: secretKey
+
+            - name: POSTGRES_PASSWORD
+              valueFrom:  
+                secretKeyRef:
+                  name: {{ printf "%s-%s" .Release.Name "postgresql" | trunc 63 | trimSuffix "-" }}
+                  key: postgres-password
+
+            - name: POSTGRES_HOST
+              value: {{ printf "%s-%s" .Release.Name "postgresql" | trunc 63 | trimSuffix "-" }}
+
+      restartPolicy: OnFailure
+  backoffLimit: 5

--- a/helm_deploy/django-app/templates/secret.yaml
+++ b/helm_deploy/django-app/templates/secret.yaml
@@ -6,4 +6,4 @@ type: Opaque
 data:
   secretKey: "ZEdocGMybHpWR2hsVTJWamNtVjBTMlY1VG05MGFHbHVaMVJ2VTJWbFNHVnlaUzQ9"
   postgresDatabase: "ZGphbmdvX3JlZmVyZW5jZQ=="
-  postgresUser: "ZGphbmdv"
+  postgresUser: "cG9zdGdyZXM="

--- a/helm_deploy/django-app/values.yaml
+++ b/helm_deploy/django-app/values.yaml
@@ -7,11 +7,11 @@ replicaCount: 1
 image:
   repository: 926803513772.dkr.ecr.eu-west-1.amazonaws.com/cloud-platform-demo-app
   tag: latest
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
 
 service:
   type: ClusterIP
-  port: 80
+  port: 8000
 
 ingress:
   enabled: true
@@ -19,12 +19,13 @@ ingress:
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   path: /
-  hosts:
-    - helm-demo.apps.cloud-platforms-test.k8s.integration.dsd.io
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
+
+deploy: 
+  host: helm-demo.apps.cloud-platforms-test.k8s.integration.dsd.io
 
 postgresql:
     postgresUser: "django"

--- a/helm_deploy/django-app/values.yaml
+++ b/helm_deploy/django-app/values.yaml
@@ -25,7 +25,7 @@ ingress:
   #      - chart-example.local
 
 deploy: 
-  hosts: helm-demo.apps.cloud-platforms-test.k8s.integration.dsd.io
+  host: helm-demo.apps.cloud-platforms-test.k8s.integration.dsd.io
 
 postgresql:
     postgresUser: ""

--- a/helm_deploy/django-app/values.yaml
+++ b/helm_deploy/django-app/values.yaml
@@ -25,10 +25,12 @@ ingress:
   #      - chart-example.local
 
 deploy: 
-  host: helm-demo.apps.cloud-platforms-test.k8s.integration.dsd.io
+  hosts: helm-demo.apps.cloud-platforms-test.k8s.integration.dsd.io
 
 postgresql:
-    postgresUser: "django"
+    postgresUser: ""
     postgresPassword: ""
     postgresDatabase: "django_reference"
     postgresHost: ""
+    persistence:
+      enabled: false

--- a/helm_deploy/django-app/values.yaml
+++ b/helm_deploy/django-app/values.yaml
@@ -25,7 +25,7 @@ ingress:
   #      - chart-example.local
 
 deploy: 
-  host: helm-demo.apps.cloud-platforms-test.k8s.integration.dsd.io
+  host: ""
 
 postgresql:
     postgresUser: ""


### PR DESCRIPTION
**WHAT**
1. Enabled Django DB connection timeout in settings.py. 
2. Created a liveness probe and changed 'ALLOWED_HOSTS' in Django settings to allow internal IP.
3. Created Job for database migration.
4. Modified values file.

**WHY**
1. As the Helm chart calls the stable release of postgres, the pods start at the same time. The pod containing the app completes before the postgres pod, leaving it without a connection to the database. By enabling db connection timeout in the app it allows it to recycle the connection if none is present. 
2. By creating a liveness probe, the pod will be restarted and the db connection will be re-established.
3. This job is responsible for applying and unapplying migrations. 
4. There are a few values that had to be changed to allow deployment. Namely, the postgres username (which was incorrectly defined) and setting persistent volumes in postgres to false.  