### PR TITLE
Change Helm Deployment Interpolation

### DIFF
--- a/helm_deploy/django-app/templates/deployment.yaml
+++ b/helm_deploy/django-app/templates/deployment.yaml
@@ -29,22 +29,13 @@ spec:
               fieldRef:
                 fieldPath: status.podIP
           - name: SECRET_KEY
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "django-app.fullname" . }}
-                key: secretKey
+            value: {{ .Values.deploy.secretKey | quote }}
           - name: SERVER_NAME
             value: {{required "URL is required" .Values.deploy.host | quote }}
           - name: POSTGRES_USER
-            valueFrom:
-              secretKeyRef:
-                name: {{ template "django-app.fullname" . }}
-                key: postgresUser
+            value: {{ .Values.postgresql.postgresUser }}
           - name: POSTGRES_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: {{ printf "%s-%s" .Release.Name "postgresql" | trunc 63 | trimSuffix "-" }}
-                key: postgres-password
+            value: {{ .Values.postgresql.postgresPassword }}
           - name: POSTGRES_HOST
             value: {{ printf "%s-%s" .Release.Name "postgresql" | trunc 63 | trimSuffix "-" }}
           - name: POSTGRES_DATABASE

--- a/helm_deploy/django-app/templates/deployment.yaml
+++ b/helm_deploy/django-app/templates/deployment.yaml
@@ -29,17 +29,29 @@ spec:
               fieldRef:
                 fieldPath: status.podIP
           - name: SECRET_KEY
-            value: {{ .Values.deploy.secretKey | quote }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "django-app.fullname" . }}
+                key: secretKey
           - name: SERVER_NAME
             value: {{required "URL is required" .Values.deploy.host | quote }}
           - name: POSTGRES_USER
-            value: {{ .Values.postgresql.postgresUser }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "django-app.fullname" . }}
+                key: postgresUser
           - name: POSTGRES_PASSWORD
-            value: {{ .Values.postgresql.postgresPassword }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "django-app.fullname" . }}
+                key: postgresPassword
           - name: POSTGRES_HOST
             value: {{ printf "%s-%s" .Release.Name "postgresql" | trunc 63 | trimSuffix "-" }}
           - name: POSTGRES_DATABASE
-            value: {{ .Values.postgresql.postgresDatabase }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "django-app.fullname" . }}
+                key: postgresDatabase
           ports:
             - containerPort: 8000
           livenessProbe:

--- a/helm_deploy/django-app/templates/job-migration.yaml
+++ b/helm_deploy/django-app/templates/job-migration.yaml
@@ -12,14 +12,23 @@ spec:
           command: ["/bin/bash","-c","python3 manage.py migrate"]
           env:
             - name: POSTGRES_USER
-              value: {{ .Values.postgresql.postgresUser }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "django-app.fullname" . }}
+                  key: postgresUser
 
             - name: SECRET_KEY
-              value: {{ .Values.deploy.secretKey | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "django-app.fullname" . }}
+                  key: secretKey
 
             - name: POSTGRES_PASSWORD
-              value: {{ .Values.postgresql.postgresPassword }}
-
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "django-app.fullname" . }}
+                  key: postgresPassword
+                  
             - name: POSTGRES_HOST
               value: {{ printf "%s-%s" .Release.Name "postgresql" | trunc 63 | trimSuffix "-" }}
 

--- a/helm_deploy/django-app/templates/job-migration.yaml
+++ b/helm_deploy/django-app/templates/job-migration.yaml
@@ -12,22 +12,13 @@ spec:
           command: ["/bin/bash","-c","python3 manage.py migrate"]
           env:
             - name: POSTGRES_USER
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "django-app.fullname" . }}
-                  key: postgresUser
+              value: {{ .Values.postgresql.postgresUser }}
 
             - name: SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: {{ template "django-app.fullname" . }}
-                  key: secretKey
+              value: {{ .Values.deploy.secretKey | quote }}
 
             - name: POSTGRES_PASSWORD
-              valueFrom:  
-                secretKeyRef:
-                  name: {{ printf "%s-%s" .Release.Name "postgresql" | trunc 63 | trimSuffix "-" }}
-                  key: postgres-password
+              value: {{ .Values.postgresql.postgresPassword }}
 
             - name: POSTGRES_HOST
               value: {{ printf "%s-%s" .Release.Name "postgresql" | trunc 63 | trimSuffix "-" }}

--- a/helm_deploy/django-app/templates/secret.yaml
+++ b/helm_deploy/django-app/templates/secret.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ template "django-app.fullname" . }}
 type: Opaque
 data:
-  secretKey: "ZEdocGMybHpWR2hsVTJWamNtVjBTMlY1VG05MGFHbHVaMVJ2VTJWbFNHVnlaUzQ9"
-  postgresDatabase: "ZGphbmdvX3JlZmVyZW5jZQ=="
-  postgresUser: "cG9zdGdyZXM="
+  secretKey: {{ .Values.deploy.secretKey | b64enc | quote }}
+  postgresDatabase: {{ .Values.postgresql.postgresDatabase | b64enc | quote }}
+  postgresUser: {{ .Values.postgresql.postgresUser | b64enc | quote }}
+  postgresPassword: {{ .Values.postgresql.postgresPassword | b64enc | quote }}

--- a/helm_deploy/django-app/values.yaml
+++ b/helm_deploy/django-app/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 1
+replicaCount: 3
 
 image:
   repository: 926803513772.dkr.ecr.eu-west-1.amazonaws.com/cloud-platform-demo-app
@@ -26,10 +26,11 @@ ingress:
 
 deploy: 
   host: ""
+  secretKey: "EdocGMybHpWR2hsVTJWamNtVjBTMlY1VG05MGFHbHVaMVJ2VTJWbFNHVnlaUzQ9"
 
 postgresql:
-    postgresUser: ""
-    postgresPassword: ""
+    postgresUser: "postgres"
+    postgresPassword: "hdjhfsjkdfgsghfjgshdfgsdfkhkjdf"
     postgresDatabase: "django_reference_app"
     postgresHost: ""
     persistence:

--- a/helm_deploy/django-app/values.yaml
+++ b/helm_deploy/django-app/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 3
+replicaCount: 1
 
 image:
   repository: 926803513772.dkr.ecr.eu-west-1.amazonaws.com/cloud-platform-demo-app


### PR DESCRIPTION
**WHAT**
1. Populated the values.yaml file so the deployment values are interpolated from values.yaml rather than secrets. 
2. Change application pod replica set to three. 

**WHY**
1. After a chat with Kerin, this is the recognised best practice which allows us to define more than one values.yaml (for staging/prod etc).
2. This will allow us to perform a zero downtime deployment. 

**NOTES**
The values file will be left in plain text for the reference application to demonstrate a deployment in a 'quick start' environment. 