### PR TITLE
Add /metrics endpoint to the Reference Application

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,12 +3,11 @@ jobs:
   build:
     working_directory: /app
     docker:
-      - image: ${ECR_ENDPOINT}/cloud-platform-circle-workers:reference-app
+      - image: ${ECR_ENDPOINT}/cloud-platform/circle-workers:reference-app
         # environment variables for all commands executed in the primary container
         environment:
           GITHUB_TEAM_NAME_SLUG: cloud-platform
-          APPLICATON_DEPLOY_NAME: django-app-circleci
-          APPLICATION_HOST_URL: showthething.apps.non-production.k8s.integration.dsd.io
+          APPLICATON_DEPLOY_NAME: demo-app
     steps:
       - checkout
       - setup_remote_docker:

--- a/django_reference_app/settings.py
+++ b/django_reference_app/settings.py
@@ -27,7 +27,7 @@ DEBUG = True
 
 ALLOWED_HOSTS = ['*']
 # os.environ.get('SERVER_IP', '127.0.0.1'),
-# #os.environ.get('SERVER_NAME', 'localhost'),
+# os.environ.get('SERVER_NAME', 'localhost'),
 
 
 # Application definition

--- a/django_reference_app/settings.py
+++ b/django_reference_app/settings.py
@@ -25,10 +25,10 @@ SECRET_KEY = os.environ.get('SECRET_KEY',
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = [
-    os.environ.get('SERVER_IP', '127.0.0.1'),
-    os.environ.get('SERVER_NAME', 'localhost'),
-]
+ALLOWED_HOSTS = ['*']
+# os.environ.get('SERVER_IP', '127.0.0.1'),
+# #os.environ.get('SERVER_NAME', 'localhost'),
+
 
 # Application definition
 
@@ -41,10 +41,12 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'govuk_template_base',
     'guestbook',
-    'govuk_forms'
+    'govuk_forms',
+    'django_prometheus',
 ]
 
 MIDDLEWARE = [
+    'django_prometheus.middleware.PrometheusBeforeMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -52,6 +54,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'django_prometheus.middleware.PrometheusAfterMiddleware',
 ]
 
 ROOT_URLCONF = 'django_reference_app.urls'

--- a/django_reference_app/urls.py
+++ b/django_reference_app/urls.py
@@ -15,6 +15,7 @@ Including another URLconf
 """
 from django.urls import include, path
 from django.views.generic import TemplateView
+from django.conf.urls import url
 
 
 homepage_view = TemplateView.as_view(
@@ -27,4 +28,5 @@ homepage_view = TemplateView.as_view(
 urlpatterns = [
     path('', homepage_view, name='homepage'),
     path('guestbook/', include('guestbook.urls', namespace='guestbook')),
+    url('', include('django_prometheus.urls')),
 ]

--- a/kubectl_deploy/django/service-monitor.yaml
+++ b/kubectl_deploy/django/service-monitor.yaml
@@ -1,0 +1,11 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: django-ref-app
+spec:
+  selector:
+    matchLabels:
+      app: django-ref-app
+  endpoints:
+  - port: metrics
+    interval: 15s

--- a/kubectl_deploy/django/service-monitor.yaml
+++ b/kubectl_deploy/django/service-monitor.yaml
@@ -9,3 +9,4 @@ spec:
   endpoints:
   - port: metrics
     interval: 15s
+    

--- a/kubectl_deploy/django/service.yaml
+++ b/kubectl_deploy/django/service.yaml
@@ -2,6 +2,8 @@ kind: Service
 apiVersion: v1
 metadata:
   name: django-service
+  labels:
+    app: django-ref-app   
 spec:
   selector:
     app: django-ref-app
@@ -9,5 +11,8 @@ spec:
   - protocol: TCP
     port: 8000
     targetPort: 8000
+    name: metrics
   type: NodePort
+  
+  
 

--- a/kubectl_deploy/django/service.yaml
+++ b/kubectl_deploy/django/service.yaml
@@ -14,5 +14,4 @@ spec:
     name: metrics
   type: NodePort
   
-  
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ django-govuk-forms==0.6
 psycopg2-binary==2.7.4
 boto3==1.7.10
 flake8==3.5.0
+django-prometheus==1.0.15


### PR DESCRIPTION
WHAT
Add the /metrics endpoint to the reference application (using django_prometheus) so Prometheus can scape metrics from it

WHY
This will be used to show teams how the endpoint looks and be used as a refrence

