### PR TITLE
Helm deploy changes for Ref App

### DIFF
--- a/helm_deploy/django-app/templates/service-monitor.yaml
+++ b/helm_deploy/django-app/templates/service-monitor.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "django-app.fullname" . }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "django-app.name" . }}
+  endpoints:
+  - port: metrics
+    interval: 15s
+    

--- a/helm_deploy/django-app/templates/service.yaml
+++ b/helm_deploy/django-app/templates/service.yaml
@@ -12,6 +12,7 @@ spec:
     - port: 8000
       targetPort: 8000
       protocol: TCP
+      name: metrics
   type: ClusterIP
   selector:
     app: {{ template "django-app.name" . }}


### PR DESCRIPTION
WHAT
Add service monitor and change to service manifest for helm deploy of ref app 
WHY
This change is needed for the instrumentation of the ref app and enable Prometheus to discover the new /metrics end point and scrape